### PR TITLE
Add support for '-file' parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ popd && popd && \
 
 Use the `--github-issue-group-by` option to switch between posting issues on a per `file` and `folder` basis.
 
+Instead of specifying the whole of GitHub issue body on the command-line, you can place it in a file and use the `--github-issue-body-file` parameter instead. The file contents should meet the same requirements as the `--github-issue-body` parameter. For example:
+
+```
+[...]
+./compatibility-scanner.php ... --github-issue-body-file=/tmp/my-github-issue-body.txt
+```
+
+The same applies to the `--zendesk-issue-body` parameter. 
+
 ### Zendesk functionality
 
 If you wish to also create Zendesk tickets to notify about the issues found, you can add parameters such as these to the command:


### PR DESCRIPTION
Add generic support for '-file' parameters, activate for both `--github-issue-body` and `--zendesk-ticket-body`. 

With this addition, the script can be called with `--github-issue-body-file=/tmp/github-issue-body.txt`, and the file containing the whole GitHub issue body. This is instead of calling `--github-issue-body` with the whole string.