### PR TITLE
Special utility for Zendesk ticket creation, implement --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vip-go-compatibility-scanner
 
-Find issues in selected repositories using PHPCS.
+Find issues in selected repositories using PHPCS, report to GitHub.
 
 This tool is to be used to search for any (compatibility) issues in VIP Go repositories. It will scan a given repository with PHPCS, using a specified PHPCS standard, and then post GitHub issue for each directory that has any detected issues detailing what was found. It will add labels to each issue created, if specified, and print links to the labels in its output. Note that the tool needs to have the repository cloned and ready to be used when started.
 
@@ -10,10 +10,13 @@ The tool will also create Zendesk tickets using the REST API if set up to do so.
 
 The tool uses [vip-go-ci](https://github.com/automattic/vip-go-ci/) as a library, and uses some of its dependencies as well. See below.
 
+Note that the tool has two parts:
+ * The compatibility-scanner.php script will scan using PHPCS and report to GitHub. It will also save to a local database file the information needed to create Zendesk tickets later, by the other part of this tool.
+ * The zendesk-tickets-create.php script will create Zendesk tickets with URLs to the GitHub issues. It utilises the local database file for this purpose.
 
 ## System requirements
 
-`vip-go-compatibility-scanner` requires PHP 7.3 or later. PHP 7.4 is preferred.
+`vip-go-compatibility-scanner` requires PHP 7.3 or later. PHP 7.4 is preferred. SQLite support is required if the Zendesk functionality is to be used.
 
 ## Installing
 
@@ -25,7 +28,7 @@ This will result in `vip-go-compatibility-scanner`, `vip-go-ci` and other depend
 
 ## Usage for a single repository
 
-The tool itself is meant to be used on a per-repo bases. Here is an example of how it can be run:
+The compatibility-scanner.php script is meant to be used on a per-repo bases. Here is an example of how it can be run:
 
 ```
 pushd /tmp && \
@@ -46,17 +49,24 @@ Instead of specifying the whole of GitHub issue body on the command-line, you ca
 ./compatibility-scanner.php ... --github-issue-body-file=/tmp/my-github-issue-body.txt
 ```
 
-The same applies to the `--zendesk-issue-body` parameter. 
+Note: If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
+
+```
+[...]
+./compatibility-scanner.php ... --zendesk-db=/tmp/zendeskdb.sqlite
+```
 
 ### Zendesk functionality
 
-If you wish to also create Zendesk tickets to notify about the issues found, you can add parameters such as these to the command:
+If you wish to also create Zendesk tickets to notify about the issues found, you can use the zendesk-tickets-create.php script:
 
 ```
---zendesk-access-username="user@email" --zendesk-access-token="xyz" --zendesk-subdomain="myzendesksubdomain" --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-csv-data-path="file.csv"
+./zendesk-tickets-create.php --zendesk-access-username="user@email" --zendesk-access-token="xyz" --zendesk-subdomain="myzendesksubdomain" --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-csv-data-path="file.csv --zendesk-db=/tmp/zendeskdb.sqlite"
 ```
 
 The `--zendesk-ticket-body` parameter supports `%linebreak%` strings, which will be replaced with actual line-breaks. 
+
+You can use the `--zendesk-ticket-body-file` parameter to load the ticket body from a file. Line breaks will be preserved.
 
 The `--zendesk-ticket-tags` parameter is optional and supports a comma separated list of tags to be added. 
 
@@ -91,5 +101,5 @@ The parameters are the following, respectively:
  * PHPCS runtime set
  * Git branch to check out
 
-There are also optional parameters for Zendesk. See help message.
+There is also optional parameter for Zendesk. See help message.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Included is a script to install `vip-go-compatibility-scanner`. You can use it l
 
 This will result in `vip-go-compatibility-scanner`, `vip-go-ci` and other dependencies being installed in your home directory under `vip-go-ci-tools`.
 
-## Usage for a single repository
+## Scanning a single repository
 
 The compatibility-scanner.php script is meant to be used on a per-repo bases. Here is an example of how it can be run:
 
@@ -45,30 +45,34 @@ Use the `--github-issue-group-by` option to switch between posting issues on a p
 Instead of specifying the whole of GitHub issue body on the command-line, you can place it in a file and use the `--github-issue-body-file` parameter instead. The file contents should meet the same requirements as the `--github-issue-body` parameter. For example:
 
 ```
-[...]
-./compatibility-scanner.php ... --github-issue-body-file=/tmp/my-github-issue-body.txt
+./compatibility-scanner.php [...] --github-issue-body-file=/tmp/my-github-issue-body.txt
 ```
 
-Note: If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
+<b>Note: If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
 
 ```
-[...]
-./compatibility-scanner.php ... --zendesk-db=/tmp/zendeskdb.sqlite
+./compatibility-scanner.php [...] --zendesk-db=/tmp/zendeskdb.sqlite
 ```
 
-### Zendesk functionality
+You can run many scans in a sequence and then run the Zendesk script.
 
-If you wish to also create Zendesk tickets to notify about the issues found, you can use the zendesk-tickets-create.php script:
+You can use the `--dry-run` parameter to do a test run and see how many GitHub issues would be opened.
+
+### Creating Zendesk tickets
+
+If you wish to also create Zendesk tickets to notify about the GitHub issues opened, you can use the zendesk-tickets-create.php script. This script will determine, from a CSV file specified, with what users to open up tickets. It will attempt to open up only one ticket per user, listing all the GitHub issues opened up earlier by the scanning script.
+
+Usage is as follow:
 
 ```
-./zendesk-tickets-create.php --zendesk-access-username="user@email" --zendesk-access-token="xyz" --zendesk-subdomain="myzendesksubdomain" --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-csv-data-path="file.csv --zendesk-db=/tmp/zendeskdb.sqlite"
+./zendesk-tickets-create.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/" --zendesk-subdomain="myzendesksubdomain" --zendesk-access-username="user@email" --zendesk-access-token="xyz"  --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-ticket-status=PENDING --zendesk-csv-data-path="file.csv --zendesk-db=/tmp/zendeskdb.sqlite"
 ```
 
-The `--zendesk-ticket-body` parameter supports `%linebreak%` strings, which will be replaced with actual line-breaks. 
-
-You can use the `--zendesk-ticket-body-file` parameter to load the ticket body from a file. Line breaks will be preserved.
+The `--zendesk-ticket-body` parameter supports `%linebreak%` strings, which will be replaced with actual line-breaks. You can use the `--zendesk-ticket-body-file` parameter to load the ticket body from a file instead. Line breaks will be preserved.
 
 The `--zendesk-ticket-tags` parameter is optional and supports a comma separated list of tags to be added. 
+
+The `--zendesk-ticket-group-id` parameter is optional as well, and expects an integer. 
 
 The `--zendesk-csv-data-path` parameter should point to a CSV file that is used to pair together the repository and the email address used as assignee of the Zendesk ticket. The CSV should look like this:
 
@@ -78,6 +82,8 @@ email@email,repoowner/reponame
 ```
 
 The first line should always specify columns. You can specify as many repositories and emails as needed.
+
+This script also supports the `--dry-run` parameter; this will output tickets created.
 
 ## Usage for multiple repositories
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Instead of specifying the whole of GitHub issue body on the command-line, you ca
 ./compatibility-scanner.php [...] --github-issue-body-file=/tmp/my-github-issue-body.txt
 ```
 
-<b>Note: If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
+<b>Note:</b> If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
 
 ```
 ./compatibility-scanner.php [...] --zendesk-db=/tmp/zendeskdb.sqlite

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Find issues in selected repositories using PHPCS, report to GitHub.
 
-This tool is to be used to search for any (compatibility) issues in VIP Go repositories. It will scan a given repository with PHPCS, using a specified PHPCS standard, and then post GitHub issue for each directory that has any detected issues detailing what was found. It will add labels to each issue created, if specified, and print links to the labels in its output. Note that the tool needs to have the repository cloned and ready to be used when started.
+This tool is to be used to search for any (compatibility) issues in VIP Go repositories. It will scan a given repository with PHPCS, using a specified PHPCS standard, and then post GitHub issue for each folder that has any detected issues detailing what was found. It will add labels to each issue created, if specified, and print links to the labels in its output. Note that the tool needs to have the repository cloned and ready to be used when started.
 
 This tool can be used for any GitHub repository and with any PHPCS standard. Issues can be posted on a per-file basis.
 
@@ -48,6 +48,12 @@ Instead of specifying the whole of GitHub issue body on the command-line, you ca
 ./compatibility-scanner.php [...] --github-issue-body-file=/tmp/my-github-issue-body.txt
 ```
 
+To skip reporting of certain PHPCS issues, use the `--phpcs-sniffs-exclude` parameter, like this:
+
+```
+./compatibility-scanner.php [...] --phpcs-sniffs-exclude=My.Sniff.function
+```
+
 <b>Note:</b> If you want to open up Zendesk tickets later, use the `--zendesk-db` parameter, like this:
 
 ```
@@ -60,12 +66,12 @@ You can use the `--dry-run` parameter to do a test run and see how many GitHub i
 
 ### Creating Zendesk tickets
 
-If you wish to also create Zendesk tickets to notify about the GitHub issues opened, you can use the zendesk-tickets-create.php script. This script will determine, from a CSV file specified, with what users to open up tickets. It will attempt to open up only one ticket per user, listing all the GitHub issues opened up earlier by the scanning script.
+If you wish to also create Zendesk tickets to notify about the GitHub issues opened, you can use the `zendesk-tickets-create.php` script. This script will determine, from a CSV file specified, with what users to open up tickets. It will attempt to open up only one ticket per user, listing all the GitHub issues opened up earlier by the scanning script.
 
 Usage is as follow:
 
 ```
-./zendesk-tickets-create.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/" --zendesk-subdomain="myzendesksubdomain" --zendesk-access-username="user@email" --zendesk-access-token="xyz"  --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-ticket-status=PENDING --zendesk-csv-data-path="file.csv --zendesk-db=/tmp/zendeskdb.sqlite"
+./zendesk-tickets-create.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/" --zendesk-subdomain="myzendesksubdomain" --zendesk-access-username="user@email" --zendesk-access-token="xyz"  --zendesk-ticket-subject="PHP Upgrade: Issues that need solving" --zendesk-ticket-body="Hi! %linebreak% Some issues were found. %linebreak% See issues here: %github_issues_link%" --zendesk-ticket-status=PENDING --zendesk-csv-data-path="file.csv" --zendesk-db="/tmp/zendeskdb.sqlite"
 ```
 
 The `--zendesk-ticket-body` parameter supports `%linebreak%` strings, which will be replaced with actual line-breaks. You can use the `--zendesk-ticket-body-file` parameter to load the ticket body from a file instead. Line breaks will be preserved.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The tool will also create Zendesk tickets using the REST API if set up to do so.
 The tool uses [vip-go-ci](https://github.com/automattic/vip-go-ci/) as a library, and uses some of its dependencies as well. See below.
 
 Note that the tool has two parts:
- * The compatibility-scanner.php script will scan using PHPCS and report to GitHub. It will also save to a local database file the information needed to create Zendesk tickets later, by the other part of this tool.
- * The zendesk-tickets-create.php script will create Zendesk tickets with URLs to the GitHub issues. It utilises the local database file for this purpose.
+ * The `compatibility-scanner.php` script will scan using PHPCS and report to GitHub. It will also save to a local database file the information needed to create Zendesk tickets later, by the other part of this tool.
+ * The `zendesk-tickets-create.php` script will create Zendesk tickets with URLs to the GitHub issues. It utilises the local database file for this purpose.
 
 ## System requirements
 

--- a/open-issues.php
+++ b/open-issues.php
@@ -9,7 +9,8 @@ function vipgocs_open_issues(
 	$all_results,
 	$git_branch,
 	$labels,
-	$assignees = array()
+	$assignees = array(),
+	$emulate_only = false
 ) {
 
 	/*
@@ -17,12 +18,12 @@ function vipgocs_open_issues(
 	 * we do.
 	 */
 	$issue_statistics = array(
-		'issues_found'	=> 0,
-		'issues_opened'	=> 0,
+		'phpcs_issues_found'	=> 0,
+		'github_issues_opened'	=> 0,
 	);
 
 	vipgoci_log(
-		'Opening up issues on GitHub for problems found',
+		( $emulate_only ? 'Emulating o' : 'O' ) . 'pening up issues on GitHub for problems found',
 		array(
 			'repo-owner'			=> $options['repo-owner'],
 			'repo-name'			=> $options['repo-name'],
@@ -30,6 +31,7 @@ function vipgocs_open_issues(
 			'github_issue_body'		=> $options['github-issue-body'],
 			'issues'			=> $all_results,
 			'assignees'			=> $assignees,
+			'emulate_only'			=> $emulate_only,
 		)
 	);
 
@@ -101,7 +103,7 @@ function vipgocs_open_issues(
 			$error_msg .=
 				PHP_EOL . PHP_EOL;
 
-			$issue_statistics['issues_found']++;
+			$issue_statistics['phpcs_issues_found']++;
 		}
 
 		$github_url =
@@ -140,14 +142,15 @@ function vipgocs_open_issues(
 			$github_req_body['assignees'] = $assignees;
 		}
 
+		if ( false === $emulate_only ) {
+			$res = vipgoci_github_post_url(
+				$github_url,
+				$github_req_body,
+				$options['token']
+			);
+		}
 
-		$res = vipgoci_github_post_url(
-			$github_url,
-			$github_req_body,
-			$options['token']
-		);
-
-		$issue_statistics['issues_opened']++;
+		$issue_statistics['github_issues_opened']++;
 
 		/*
 		 * Clean up and return.
@@ -164,7 +167,7 @@ function vipgocs_open_issues(
 	}
 
 	vipgoci_log(
-		'Finished opening up issues on GitHub',
+		( $emulate_only ? 'Emulated' : 'Finished' ) . ' opening up issues on GitHub',
 		array(
 			'issue_statistics' => $issue_statistics,
 		)

--- a/options.php
+++ b/options.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Read file specified by option value
+ * if the option value is present and the
+ * file exists, place file content in complementary
+ * parameter.
+ */
+function vipgocs_file_option_process_complementary(
+	&$options,
+	$option_name
+) {
+	$option_name_with_file =
+		$option_name . '-file';
+
+	if ( ! isset(
+		$options[ $option_name_with_file ]
+	) ) {
+		return;
+	}
+
+	/*
+	 * Cannot specify both parameters.
+	 */
+	if ( isset( $options[ $option_name ] ) ) {
+		vipgoci_sysexit(
+			'Cannot specify both --' . $option_name . ' and ' .
+				'--' . $option_name_with_file
+		);
+	}
+
+	vipgoci_option_file_handle(
+		$options,
+		$option_name_with_file
+	);
+
+	$tmp_file_contents =
+		file_get_contents(
+			$options[ $option_name_with_file ]
+		);
+
+	if ( false === $tmp_file_contents ) {
+		vipgoci_sysexit(
+			'Unable to read file specified by ' .
+				'--' . $option_name_with_file,
+			array(
+				$option_name_with_file =>
+					$options[ $option_name_with_file ],
+			)
+		);
+	}
+
+	$options[ $option_name ] =
+		$tmp_file_contents;
+
+	unset(
+		$tmp_file_contents
+	);
+}
+

--- a/tests/OpenIssuesOpenIssuesTest.php
+++ b/tests/OpenIssuesOpenIssuesTest.php
@@ -164,8 +164,8 @@ final class OpenIssuesOpenIssuesTest extends TestCase {
 
 		$this->assertEquals(
 			array(
-				'issues_found' => 3,
-				'issues_opened' => 3,
+				'phpcs_issues_found' => 3,
+				'github_issues_opened' => 3,
 			),
 			$issue_statistics,
 		);

--- a/tests/OptionsFileOptionProcessComplementaryTest.php
+++ b/tests/OptionsFileOptionProcessComplementaryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class OptionsFileOptionProcessComplementaryTest extends TestCase {
+	var $options = array(
+	);
+
+	var $text_file_path = null;
+
+	protected function setUp() :void {
+		$this->text_file_path = vipgoci_save_temp_file(
+			'tmp-complementary-file',
+			'txt',
+			'My Text File Contents'
+		);
+	}
+
+	protected function tearDown() :void {
+		if ( ! empty(
+			$this->text_file_path
+		) {
+			unlink(
+				$this->text_file_path
+			);
+		}
+	}
+	
+	/**
+	 * @covers ::vipgocs_file_option_process_complementary
+	 */
+	public function testComplementaryOption1() {
+		$this->options['my-text-file'] =
+			$this->text_file_path;
+
+		vipgocs_file_option_process_complementary(
+			$this->options,
+			'my-text'
+		);
+
+		$this->assertEquals(
+			array(
+				'my-text-file'	=> $this->text_file_path,
+				'my-text'	=> 'My Text File Contents',
+			),
+			$this->options
+		);
+	}
+
+	/**
+	 * @covers ::vipgocs_file_option_process_complementary
+	 */
+	public function testComplementaryOption2() {
+		$this->options['my-text'] =
+			'MyText';
+
+		vipgocs_file_option_process_complementary(
+			$this->options,
+			'my-text'
+		);
+
+		$this->assertEquals(
+			array(
+				'my-text'	=> 'MyText',
+			),
+			$this->options
+		);
+	}
+}

--- a/tests/OptionsFileOptionProcessComplementaryTest.php
+++ b/tests/OptionsFileOptionProcessComplementaryTest.php
@@ -21,7 +21,7 @@ final class OptionsFileOptionProcessComplementaryTest extends TestCase {
 	protected function tearDown() :void {
 		if ( ! empty(
 			$this->text_file_path
-		) {
+		) ) {
 			unlink(
 				$this->text_file_path
 			);

--- a/tests/ZendeskDbTest.php
+++ b/tests/ZendeskDbTest.php
@@ -1,0 +1,206 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class ZendeskDbTest extends TestCase {
+	protected function setUp() :void {
+		$this->db_file = vipgoci_save_temp_file(
+			'tmp-db-file',
+			'sqlite',
+			''
+		);
+	}
+
+	protected function tearDown() :void {
+		if ( ! empty(
+			$this->db_file
+		) ) {
+			unlink(
+				$this->db_file
+			);
+		}
+	}
+	
+	public function testZendeskDb1() {
+		$db_conn = vipgocs_zendesk_db_open(
+			$this->db_file
+		);
+
+
+		$this->assertNotEmpty(
+			$db_conn
+		);
+
+		$gh_issues = vipgocs_zendesk_db_get_github_issues(
+			$db_conn
+		);
+
+		$this->assertEquals(
+			array(),
+			$gh_issues
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner1',
+			'r-name1',
+			'http://github.com/test1'
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner1',
+			'r-name1',
+			'http://github.com/test2'
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner1',
+			'r-name1',
+			'http://github.com/test3'
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner1',
+			'r-name2',
+			'http://github.com/test4'
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner2',
+			'r-name1',
+			'http://github.com/test5'
+		);
+
+		vipgocs_zendesk_db_write_github_issue(
+			$db_conn,
+			'r-owner2',
+			'r-name1',
+			'http://github.com/test6'
+		);
+
+
+		$gh_issues = vipgocs_zendesk_db_get_github_issues(
+			$db_conn
+		);
+
+		$this->assertEquals(
+			array(
+				'r-owner1/r-name1' => array(
+					'repo_owner' => 'r-owner1',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test1',
+						'http://github.com/test2',
+						'http://github.com/test3',
+					)
+				),
+
+				'r-owner1/r-name2' => array(
+					'repo_owner' => 'r-owner1',
+					'repo_name' => 'r-name2',
+					'github_issues_urls' => array(
+						'http://github.com/test4'
+					)
+				),
+
+				'r-owner2/r-name1' => array(
+					'repo_owner' => 'r-owner2',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test5',
+						'http://github.com/test6',
+					)
+				),
+			),
+			$gh_issues
+		);
+
+		vipgocs_zendesk_db_delete_github_issue(
+			$db_conn,
+			'r-owner2',
+			'r-name1',
+			'http://github.com/test5'
+		);
+
+		$gh_issues = vipgocs_zendesk_db_get_github_issues(
+			$db_conn
+		);
+
+		$this->assertEquals(
+			array(
+				'r-owner1/r-name1' => array(
+					'repo_owner' => 'r-owner1',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test1',
+						'http://github.com/test2',
+						'http://github.com/test3',
+					)
+				),
+
+				'r-owner1/r-name2' => array(
+					'repo_owner' => 'r-owner1',
+					'repo_name' => 'r-name2',
+					'github_issues_urls' => array(
+						'http://github.com/test4'
+					)
+				),
+
+				'r-owner2/r-name1' => array(
+					'repo_owner' => 'r-owner2',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test6',
+					)
+				),
+			),
+			$gh_issues
+		);
+
+		vipgocs_zendesk_db_delete_github_issue(
+			$db_conn,
+			'r-owner1',
+			'r-name2',
+			'http://github.com/test4'
+		);
+
+		$gh_issues = vipgocs_zendesk_db_get_github_issues(
+			$db_conn
+		);
+
+		$this->assertEquals(
+			array(
+				'r-owner1/r-name1' => array(
+					'repo_owner' => 'r-owner1',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test1',
+						'http://github.com/test2',
+						'http://github.com/test3',
+					)
+				),
+				'r-owner2/r-name1' => array(
+					'repo_owner' => 'r-owner2',
+					'repo_name' => 'r-name1',
+					'github_issues_urls' => array(
+						'http://github.com/test6',
+					)
+				),
+			),
+			$gh_issues
+		);
+
+		$this->assertTrue(
+			vipgocs_zendesk_db_close(
+				$db_conn
+			)
+		);
+	}
+}
+

--- a/utils.php
+++ b/utils.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Check if we are running on PHP 7.3 or later.
+ */
+function vipgocs_env_check() {
+	if ( version_compare(
+		phpversion(),
+		'7.3.0'
+	) < 0 ) {
+		echo 'Error: PHP 7.3 is required as a minimum.' . PHP_EOL;
+		exit( 251 ); /* System problem */
+	}
+}
+
+/*
+ * Report any errors to the user.
+ */
+function vipgocs_logging_setup() {
+	ini_set( 'error_log', '' );
+
+	error_reporting( E_ALL );
+
+	ini_set( 'display_errors', 'on' );
+}
+
+/*
+ * Attempt to load vip-go-ci
+ */
+function vipgocs_vipgoci_load(
+	$options,
+	$option_name
+) {
+	if ( ! is_dir( $options[ $option_name ] ) ) {
+		echo 'Path specified in --' . $option_name . ' is invalid, is not a directory' . PHP_EOL;
+		exit(253);
+	}
+
+	if ( ! is_file( $options[ $option_name ] . '/main.php' ) ) {
+		echo 'No main.php found in --' . $option_name . ' ; is it a valid vip-go-ci installation?' . PHP_EOL;
+		exit(253);
+	}
+
+	/*
+	 * Include vip-go-ci as a library.
+	 */
+	echo 'Attempting to include vip-go-ci...' . PHP_EOL;
+
+	require_once(
+		$options[ $option_name ] . '/main.php'
+	);
+
+	vipgoci_log(
+		'Successfully included vip-go-ci'
+	);
+}
+

--- a/zendesk-api.php
+++ b/zendesk-api.php
@@ -143,6 +143,12 @@ function vipgocs_zendesk_open_ticket(
 		)
 	);
 
+	$tmp_github_issue_urls = "";
+
+	foreach( $github_issues_links as $github_issues_link ) {
+		$tmp_github_issue_urls .= '* ' . $github_issues_link . PHP_EOL;
+	}
+
 	$zendesk_api_postfields = array(
 		'ticket'	=> array(
 			'subject'	=> $options['zendesk-ticket-subject'],
@@ -153,7 +159,7 @@ function vipgocs_zendesk_open_ticket(
 						'%linebreak%',
 					),
 					array(
-						$github_issues_links[0],
+						$tmp_github_issue_urls,
 						PHP_EOL,
 					),
 					$options['zendesk-ticket-body']

--- a/zendesk-db.php
+++ b/zendesk-db.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * Open or create ZendeskDB file.
+ * Uses SQLite.
+ */
+
+function vipgocs_zendesk_db_open(
+	$path
+) {
+	vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DO,
+		'zendesk_db_open',
+		1
+	);
+
+	try {
+		$db_conn = new SQLite3(
+			$path,
+			SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE
+		);
+	}
+
+	catch ( Exception $e ) {
+		$error_msg = $e->getMessage();
+		$db_conn = null;
+	}
+
+	if ( null === $db_conn ) {
+		vipgoci_sysexit(
+			'Unable to open ZendeskDB',
+			array(
+				'file'	=> $path,
+				'error'	=> $error_msg,
+			)
+		);
+	}
+
+	$res = $db_conn->query(
+		'CREATE TABLE IF NOT EXISTS vipgocs_github_issues ( ' .
+			'id integer PRIMARY KEY, ' .
+			'repo_name TEXT NOT NULL, ' .
+			'repo_owner TEXT NOT NULL, ' .
+			'github_url TEXT NOT NULL ) '
+	);
+
+	if ( false === $res ) {
+		vipgoci_sysexit(
+			'Unable to write to ZendeskDB',
+			array(
+				'file'  => $path,
+			)
+		);
+	}
+
+
+	return $db_conn;
+}
+
+/*
+ * Close database handle.
+ */
+function vipgocs_zendesk_db_close(
+	$db_conn
+) {
+	vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DO,
+		'zendesk_db_close',
+		1
+	);
+
+	return $db_conn->close();
+}
+
+/*
+ * Write GitHub issue URL to DB along
+ * with repo-owner and repo-name.
+ */
+function vipgocs_zendesk_db_write_github_issue(
+	$db_conn,
+	$repo_owner,
+	$repo_name,
+	$github_url
+) {
+	vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DO,
+		'zendesk_db_write_github_issue',
+		1
+	);
+
+	$db_stmt = $db_conn->prepare(
+		'INSERT INTO vipgocs_github_issues ' .
+			'(repo_name, repo_owner, github_url) ' .
+			'VALUES '  .
+			'( :repo_name, :repo_owner, :github_url )'
+	);
+
+	$db_stmt->bindValue(':repo_name', $repo_name );
+	$db_stmt->bindValue(':repo_owner', $repo_owner );
+	$db_stmt->bindValue(':github_url', $github_url );
+
+	return $db_stmt->execute();
+}
+
+/*
+ * Fetch all GitHub issues from DB,
+ * merge all that belong to the same
+ * repo-owner/repo-name combination into 
+ * one group.
+ */
+function vipgocs_zendesk_db_get_github_issues(
+	$db_conn
+) {
+	vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DO,
+		'zendesk_db_get_github_issues',
+		1
+	);
+
+	$res = $db_conn->query(
+		'SELECT id, repo_name, repo_owner, github_url FROM vipgocs_github_issues ORDER BY id'
+	);
+
+	$gh_issues_groups = array();
+
+	while ( $row = $res->fetchArray() ) {
+		$key = $row['repo_owner'] . '/' . $row['repo_name'];
+
+		if ( ! isset(
+			$gh_issues_groups[ $key ]
+		) ) {
+			$gh_issues_groups[ $key ] = array(
+				'repo_owner'		=> $row['repo_owner'],
+				'repo_name'		=> $row['repo_name'],
+				'github_issues_urls'	=> array(),
+			);
+		}
+
+		$gh_issues_groups[ $key ]['github_issues_urls'][] =
+			$row['github_url'];
+	}
+
+	return $gh_issues_groups;
+}
+
+/*
+ * Delete a particular URL from
+ * Zendesk DB, matched also by repo-owner
+ * and repo-name.
+ */
+function vipgocs_zendesk_db_delete_github_issue(
+	$db_conn,
+	$repo_owner,
+	$repo_name,
+	$github_url
+) {
+	vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DO,
+		'zendesk_db_delete_github_issue',
+		1
+	);
+
+	$db_stmt = $db_conn->prepare(
+		'DELETE FROM vipgocs_github_issues ' .
+			'WHERE ' .
+			'repo_owner = :repo_owner AND ' .
+			'repo_name = :repo_name AND ' .
+			'github_url = :github_url'
+	);
+
+	$db_stmt->bindValue(':repo_name', $repo_name );
+	$db_stmt->bindValue(':repo_owner', $repo_owner );
+	$db_stmt->bindValue(':github_url', $github_url );
+
+	return $db_stmt->execute();
+}
+

--- a/zendesk-tickets-create.php
+++ b/zendesk-tickets-create.php
@@ -245,9 +245,15 @@ function vipgocs_zendesk_tickets_create() {
 	 * Check if Zendesk auth is ok
 	 */
 
-	if ( null !== vipgocs_zendesk_prepare_auth_fields(
+	if ( null === vipgocs_zendesk_prepare_auth_fields(
 		$options
 	) ) {
+		vipgoci_sysexit(
+			'Unable to submit tickets to Zendesk, parameters missing'
+		);
+	}
+
+	else {
 		if ( true !== vipgocs_zendesk_check_auth(
 			$options
 		) ) {
@@ -307,7 +313,7 @@ function vipgocs_zendesk_tickets_create() {
 	unset( $options_clean );
 
 	/*
-	 * Read in CSV data, if --zendesk-csv-data is specified
+	 * Read in CSV data
 	 */
 
 	$zendesk_csv_data = array();

--- a/zendesk-tickets-create.php
+++ b/zendesk-tickets-create.php
@@ -1,0 +1,454 @@
+#!/usr/bin/env php
+<?php
+
+require_once( __DIR__ . '/github-api.php' );
+require_once( __DIR__ . '/scan-files.php' );
+require_once( __DIR__ . '/open-issues.php' );
+require_once( __DIR__ . '/zendesk-api.php' );
+require_once( __DIR__ . '/csv-data.php' );
+require_once( __DIR__ . '/options.php' );
+require_once( __DIR__ . '/zendesk-db.php');
+require_once( __DIR__ . '/utils.php' );
+
+
+define( 'VIPGOCI_INCLUDED', true );
+
+
+/*
+ * main() -- prepare to do actual work,
+ * invoke functions that do the work.
+ */
+
+function vipgocs_zendesk_tickets_create() {
+	global $argv;
+
+	echo 'Initializing...' . PHP_EOL;
+
+	/*
+	 * Do sanity checks on our environment.
+	 */
+	vipgocs_env_check();
+
+	/*
+	 * Log startup time
+	 */
+	$startup_time = time();
+
+	/*
+	 * Report any errors to the user.
+	 */
+	vipgocs_logging_setup();
+
+	/*
+	 * Get option-values
+	 */
+	$options = getopt(
+		null,
+		array(
+			'help',
+			'vipgoci-path:',
+			'zendesk-subdomain:',
+			'zendesk-access-username:',
+			'zendesk-access-token:',
+			'zendesk-access-password:',
+			'zendesk-ticket-subject:',
+			'zendesk-ticket-body:',
+			'zendesk-ticket-body-file:',
+			'zendesk-ticket-tags:',
+			'zendesk-ticket-group-id:',
+			'zendesk-ticket-status:',
+			'zendesk-csv-data-path:',
+			'zendesk-db:'
+		)
+	);
+
+	/*
+	 * Check if any required options are missing.
+	 */
+	if (
+		( ! isset(
+			$options['vipgoci-path'],
+			$options['zendesk-subdomain'],
+			$options['zendesk-access-username'],
+			$options['zendesk-ticket-subject'],
+			$options['zendesk-csv-data-path'],
+			$options['zendesk-db']
+		) )
+		||
+                (
+                        ( ! isset(
+                                $options['zendesk-ticket-body-file']
+                        ) )
+                        &&
+                        ( ! isset(
+                                $options['zendesk-ticket-body']
+                        ) )
+                )
+		||
+                (
+                        ( ! isset(
+                                $options['zendesk-access-token']
+                        ) )
+                        &&
+                        ( ! isset(
+                                $options['zendesk-access-password']
+                        ) )
+                )
+		||
+		(
+			( isset( $options['help'] ) )
+		)
+	) {
+		if ( ! isset( $options['help'] ) ) {
+			echo 'Error: Essential parameter missing.' . PHP_EOL;
+		}
+
+		print 'Usage: ' . $argv[0] . PHP_EOL .
+			"\t" . 'Options --vipgoci-path, --zendesk-access-username, --zendesk-access-token ' . PHP_EOL .
+			"\t" . '        ( or --zendesk-access-password ), --zendesk-ticket-subject, --zendesk-ticket-body, ' . PHP_EOL .
+			"\t" . '	--zendesk-csv-data-path and --zendesk-db are mandatory parameters' . PHP_EOL .
+			PHP_EOL .
+			"\t" . "Note that some parameters have a complementary '-file' parameter (see below)." . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--vipgoci-path=STRING	            Path to were vip-go-ci lives, should be folder. ' . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--zendesk-subdomain=STRING          Subdomain to use when communicating with Zendesk. ' . PHP_EOL .
+			"\t" . '--zendesk-access-username=STRING    Username of the Zendesk user to use.' . PHP_EOL .
+			"\t" . '--zendesk-access-token=STRING       Access token to use when communicating with Zendesk REST API. ' . PHP_EOL .
+			"\t" . '--zendesk-access-password=STRING    Password to use when communicating with Zendesk REST API. ' . PHP_EOL .
+			"\t" . '                                    Use if token is not an option.' . PHP_EOL .
+			"\t" . '--zendesk-ticket-subject=STRING     Subject to use for Zendesk tickets.' . PHP_EOL .
+			"\t" . '--zendesk-ticket-body=STRING        Body of Zendesk ticket. Markdown is supported. ' . PHP_EOL .
+			"\t" . '                                    Also certain strings are replaced with other values: ' . PHP_EOL .
+			"\t" . '                                     * String %github_issues_link% will be replaced' . PHP_EOL .
+			"\t" . '                                       with link to GitHub issues' . PHP_EOL .
+			"\t" . '                                     * %linebreak% will be replaced with \n.' . PHP_EOL .
+			"\t" . '--zendesk-ticket-body-file=FILE     A file to read the content of --zendesk-ticket-body from' . PHP_EOL .
+			"\t" . '                                    instead of specifying the parameter itself.' . PHP_EOL .
+			"\t" . '--zendesk-ticket-tags=STRING        Tags to assign to Zendesk tickets. Comma separated. ' . PHP_EOL .
+			"\t" . '--zendesk-ticket-group-id=NUMBER    Zendesk group ID to assign tickets to. ' . PHP_EOL .
+			"\t" . '--zendesk-ticket-status=STRING      Status of the Zendesk tickets. Defaults to "New" ' . PHP_EOL .
+			"\t" . '--zendesk-csv-data-path=PATH        CSV data to use for Zendesk ticket creation. The ' . PHP_EOL .
+			"\t" . '                                    data is used to pair a user\'s email address to repository.' . PHP_EOL .
+			"\t" . '                                    The file should have two fields: client_email and source_repo' . PHP_EOL .
+			"\t" . '                                    -- first line of the file should be columns.' . PHP_EOL .
+			"\t" . '                                    Valid columns are: client_email, source_repo ' . PHP_EOL .
+			"\t" . '--zendesk-db=FILE                   File with URLs to GitHub issues for processing ' . PHP_EOL .
+			"\t" . '                                    by this utility. ' . PHP_EOL .
+			PHP_EOL;
+
+		exit(253);
+	}
+
+
+	/*
+	 * Attempt to load vip-go-ci
+	 */
+	vipgocs_vipgoci_load(
+		$options,
+		'vipgoci-path'
+	);
+
+	/*
+	 * Read the parameter's '-file' counterpart from file if
+	 * specified.
+	 */
+	foreach(
+		array(
+			'zendesk-ticket-body',
+		) as $tmp_file_option
+	) {
+		vipgocs_file_option_process_complementary(
+			$options,
+			$tmp_file_option
+		);
+	}
+
+	if ( strpos(
+		$options['zendesk-ticket-body'],
+		'%github_issues_link%'
+	) === false ) {
+		vipgoci_sysexit(
+			'--zendesk-ticket-body does not contain %github_issues_link%.',
+			array(
+				'zendesk-ticket-body' => $options['zendesk-ticket-body'],
+			)
+		);
+	}
+
+	/*
+	 * Parse rest of options
+	 */
+
+	if ( empty( $options['zendesk-ticket-tags'] ) ) {
+		$options['zendesk-ticket-tags'] = array();
+	}
+
+	else {
+		vipgoci_option_array_handle(
+			$options,
+			'zendesk-ticket-tags',
+			array(),
+			null,
+			',',
+			false
+		);
+	}
+
+	if ( ! empty( $options['zendesk-ticket-group-id'] ) ) {
+		$options['zendesk-ticket-group-id'] = trim(
+			$options['zendesk-ticket-group-id']
+		);
+
+		if ( ! is_numeric(
+			$options['zendesk-ticket-group-id']
+		) ) {
+			vipgoci_syexit(
+				'Invalid argument provided to option --zendesk-ticket-group-id; should be an integer',
+				array(
+					'zendesk-ticket-group-id' =>
+						$options['zendesk-ticket-group-id']
+				)
+			);
+		}
+
+		$options['zendesk-ticket-group-id'] =
+			(int) $options['zendesk-ticket-group-id'];
+	}
+
+	
+	$valid_ticket_statuses = array(
+		'new', 'open', 'pending', 'hold', 'solved', 'closed'
+	);
+
+	if ( empty( $options['zendesk-ticket-status'] ) ) {
+		$options['zendesk-ticket-status'] = 'new';
+	}
+
+	else {
+		$options['zendesk-ticket-status'] = strtolower( trim(
+			$options['zendesk-ticket-status']
+		) );
+
+		if ( ! in_array(
+			$options['zendesk-ticket-status'],
+			$valid_ticket_statuses
+		) ) {
+			vipgoci_sysexit(
+				'Invalid argument provided to option --zendesk-ticket-status; should be one of: ' . 
+					join( ', ', $valid_ticket_statuses )
+			);
+		}
+	}
+
+	/*
+	 * Check if Zendesk auth is ok
+	 */
+
+	if ( null !== vipgocs_zendesk_prepare_auth_fields(
+		$options
+	) ) {
+		if ( true !== vipgocs_zendesk_check_auth(
+			$options
+		) ) {
+			vipgoci_sysexit(
+				'Authentication with Zendesk failed',
+				array(
+					'zendesk-access-username' =>
+						@$options['zendesk-access-username'],
+
+					'zendesk-subdomain' =>
+						@$options['zendesk-subdomain'],
+				)
+			);
+		}
+
+		else {
+			vipgoci_log(
+				'Authentication with Zendesk successful'
+			);
+		}
+	}
+
+	/*
+	 * Open ZendeskDB
+	 */
+	$zendesk_db_conn = vipgocs_zendesk_db_open(
+		$options['zendesk-db']
+	);
+
+	/*
+	 * Print cleaned option-values.
+	 */
+
+	vipgoci_options_sensitive_clean(
+		null,
+		array(
+			'zendesk-access-username',
+			'zendesk-access-password',
+			'zendesk-access-token',
+		)
+	);
+
+	$options_clean = vipgoci_options_sensitive_clean(
+		$options
+	);
+
+
+	/*
+	 * Main processing starts.
+	 */
+
+	vipgoci_log(
+		'Starting up...',
+		$options_clean
+	);
+
+	unset( $options_clean );
+
+	/*
+	 * Read in CSV data, if --zendesk-csv-data is specified
+	 */
+
+	$zendesk_csv_data = array();
+	$zendesk_requestee_email = null;
+
+	$zendesk_csv_data = vipgocs_csv_parse_data(
+		$options['zendesk-csv-data-path']
+	);
+
+	if ( empty( $zendesk_csv_data ) ) {
+		vipgoci_sysexit(
+			'Read CSV file, but no data seems to have been available, or data is invalid',
+			array(
+				'zendesk-csv-data-path'		=> $options['zendesk-csv-data-path'],
+				'csv-data-count'		=> count( $zendesk_csv_data ),
+			)
+		);
+	}
+
+	$zendesk_ticket_urls = array();
+
+	/*
+	 * Get GitHub issues from DB.
+	 */
+	$zendesk_db_issues = vipgocs_zendesk_db_get_github_issues(
+		$zendesk_db_conn
+	);
+
+	/*
+	 * Loop through each repo-owner / repo-name combination
+	 * and open Zendesk ticket as needed.
+	 */
+	foreach (
+		array_keys(
+			$zendesk_db_issues
+		) as $zendesk_db_key
+	) {
+		$options['repo-owner'] = $zendesk_db_issues[ $zendesk_db_key ]['repo_owner'];
+		$options['repo-name'] = $zendesk_db_issues[ $zendesk_db_key ]['repo_name'];
+		$github_issues_links = $zendesk_db_issues[ $zendesk_db_key ]['github_issues_urls'];
+
+		$zendesk_requestee_email = vipgocs_csv_get_email_for_repo(
+			$zendesk_csv_data,
+			$options['repo-owner'],
+			$options['repo-name']
+		);
+
+		$log_msg = '';
+
+		if ( ! empty( $zendesk_requestee_email ) ) {
+			$log_msg = 'Got email for Zendesk ticket creation that matches repository owner and name';
+		}
+
+		else {
+			$log_msg = 'Got no email for Zendesk ticket creation that matches repository owner and name; will not be created';
+			continue;
+		}
+
+		vipgoci_log(
+			$log_msg,
+			array(
+				'zendesk_requestee_email'	=> $zendesk_requestee_email,
+				'repo-owner'			=> $options['repo-owner'],
+				'repo-name'			=> $options['repo-name'],
+				'zendesk-csv-data-path'		=> $options['zendesk-csv-data-path'],
+				'csv-data-count'		=> count( $zendesk_csv_data ),
+			)
+		);
+
+
+		$zendesk_ticket_url_item = vipgocs_zendesk_open_ticket(
+			$options,
+			$zendesk_requestee_email,
+			$github_issues_links
+		);
+
+		if ( ! empty(
+			$zendesk_ticket_url_item
+		) ) {
+			$zendesk_ticket_urls[] =
+				$zendesk_ticket_url_item;
+
+			foreach(
+				$github_issues_links as $github_issues_link_item
+			) {
+				vipgocs_zendesk_db_delete_github_issue(
+					$zendesk_db_conn,
+					$options['repo-owner'],
+					$options['repo-name'],
+					$github_issues_link_item
+				);
+			}
+		}
+	}
+
+	/*
+	 * Collect counter-information.
+	 */
+	$counter_report = vipgoci_counter_report(
+		VIPGOCI_COUNTERS_DUMP,
+		null,
+		null
+	);
+
+
+	/*
+	 * Log information and return.
+	 */
+	vipgoci_log(
+		'Complete, shutting down...',
+		array(
+			'run_time_seconds'	=> time() - $startup_time,
+			'run_time_measurements' =>
+				vipgoci_runtime_measure(
+					VIPGOCI_RUNTIME_DUMP,
+					null
+				),
+			'counters_report'	=> $counter_report,
+		)
+	);
+
+	if ( empty( $zendesk_ticket_urls ) ) {
+		echo 'No zendesk tickets were created' . PHP_EOL;
+	}
+
+	else {
+		echo 'Find Zendesk ticket(s) here: ' . PHP_EOL;
+
+		foreach( $zendesk_ticket_urls as $zendesk_ticket_url_item ) {
+			echo ' * ' . $zendesk_ticket_url_item . PHP_EOL;
+		}
+	}
+
+	return 0;
+}
+
+if ( ( ! defined( 'VIPGOCS_UNIT_TESTING' ) ) || ( false === VIPGOCS_UNIT_TESTING ) ) {
+	/*
+	 * Main invocation function.
+	 */
+	$status = vipgocs_zendesk_tickets_create();
+
+	exit( $status );
+}

--- a/zendesk-tickets-create.php
+++ b/zendesk-tickets-create.php
@@ -46,6 +46,7 @@ function vipgocs_zendesk_tickets_create() {
 		null,
 		array(
 			'help',
+			'dry-run:',
 			'vipgoci-path:',
 			'zendesk-subdomain:',
 			'zendesk-access-username:',
@@ -75,25 +76,25 @@ function vipgocs_zendesk_tickets_create() {
 			$options['zendesk-db']
 		) )
 		||
-                (
-                        ( ! isset(
-                                $options['zendesk-ticket-body-file']
-                        ) )
-                        &&
-                        ( ! isset(
-                                $options['zendesk-ticket-body']
-                        ) )
-                )
+		(
+			( ! isset(
+				$options['zendesk-ticket-body-file']
+			) )
+			&&
+			( ! isset(
+				$options['zendesk-ticket-body']
+			) )
+		)
 		||
-                (
-                        ( ! isset(
-                                $options['zendesk-access-token']
-                        ) )
-                        &&
-                        ( ! isset(
-                                $options['zendesk-access-password']
-                        ) )
-                )
+		(
+			( ! isset(
+				$options['zendesk-access-token']
+			) )
+			&&
+			( ! isset(
+				$options['zendesk-access-password']
+			) )
+		)
 		||
 		(
 			( isset( $options['help'] ) )
@@ -111,6 +112,9 @@ function vipgocs_zendesk_tickets_create() {
 			"\t" . "Note that some parameters have a complementary '-file' parameter (see below)." . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--vipgoci-path=STRING	            Path to were vip-go-ci lives, should be folder. ' . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--dry-run=BOOL                      If set to true, will not open Zendesk tickets, ' . PHP_EOL .
+			"\t" . '                                    but report which ones would be opened. ' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--zendesk-subdomain=STRING          Subdomain to use when communicating with Zendesk. ' . PHP_EOL .
 			"\t" . '--zendesk-access-username=STRING    Username of the Zendesk user to use.' . PHP_EOL .
@@ -147,6 +151,15 @@ function vipgocs_zendesk_tickets_create() {
 	vipgocs_vipgoci_load(
 		$options,
 		'vipgoci-path'
+	);
+
+	/*
+	 * Parse --dry-run parameter
+	*/
+	vipgoci_option_bool_handle(
+		$options,
+		'dry-run',
+		'false'
 	);
 
 	/*
@@ -422,6 +435,20 @@ function vipgocs_zendesk_tickets_create() {
 		}
 
 		unset( $tmp_item );
+
+		if ( true === $options['dry-run'] ) {
+			vipgoci_log(
+				sprintf(
+					'Would open up Zendesk ticket for user %s with links',
+						$zendesk_requestee_email
+				),
+				array(
+					'github_links'	=> $zendesk_requestee_github_links,
+				)
+			);
+
+			continue;
+		}
 
 		$zendesk_ticket_url_item = vipgocs_zendesk_open_ticket(
 			$options,


### PR DESCRIPTION
TODO:

- [x] Move Zendesk-ticket creation functionality to a special utility
- [x] Implement `--dry-run` so users can see number of PHPCS issues found and <i>would-be</i> number of created GitHub issues
- [x] Further testing
- [x] Updating README
- [x] Adding unit-tests