### PR TITLE
Update files to reflect that "main" branch is now named "trunk"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ commands:
       - run: php -v
       # Update software and install a few things
       - run: sudo apt update
-      - run: sudo docker-php-ext-install zip
+      - run: sudo apt install -y zip unzip gzip tar
+      - run: composer require --dev phpunit/phpunit ^9
       # Use production php.ini file
       - run: sudo mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
       # Install phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,28 +36,20 @@ commands:
 
 # List of images at: https://circleci.com/docs/2.0/circleci-images/
 jobs:
-  testphp73:
-    docker:
-      - image: circleci/php:7.3.22-cli
-    steps:
-      - build-cmd
-
-
-  testphp74:
-    docker:
-      - image: circleci/php:7.4.10-cli
-    steps:
-      - build-cmd
-
   testphp80:
     docker:
-      - image: circleci/php:8.0.1-cli
+      - image: cimg/php:8.0.15
+    steps:
+      - build-cmd
+
+  testphp81:
+    docker:
+      - image: cimg/php:8.1.2
     steps:
       - build-cmd
 
 workflows:
   vipgocompatibilityscannertests:
     jobs:
-     - testphp73
-     - testphp74
      - testphp80
+     - testphp81

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ commands:
       # Install all the tools vip-go-compatibility-scanner needs, remove vip-go-compatibility-scanner and vip-go-ci
       - run: bash ~/project/install.sh
       - run: rm -rf ~/vip-go-ci-tools/vip-go-compatibility-scanner ~/vip-go-ci-tools/vip-go-ci
-      # Install vip-go-ci from main branch
-      - run: pushd ~/vip-go-ci-tools && wget -O vip-go-ci.tar.gz https://github.com/Automattic/vip-go-ci/archive/main.tar.gz && tar -zxvf vip-go-ci.tar.gz && mv vip-go-ci-main vip-go-ci && rm -f vip-go-ci.tar.gz && popd
+      # Install vip-go-ci from trunk branch
+      - run: pushd ~/vip-go-ci-tools && wget -O vip-go-ci.tar.gz https://github.com/Automattic/vip-go-ci/archive/trunk.tar.gz && tar -zxvf vip-go-ci.tar.gz && mv vip-go-ci-trunk vip-go-ci && rm -f vip-go-ci.tar.gz && popd
       # Change path to vital tools needed
       - run: sed 's/HOME_DIR/\/home\/circleci\//' < ~/project/unittests.ini.dist > ~/project/unittests.ini
       # Prepare phpunit configuration file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,6 @@ commands:
       - run: sudo apt update
       - run: sudo apt install -y zip unzip gzip tar
       - run: composer require --dev phpunit/phpunit ^9
-      # Use production php.ini file
-      - run: sudo mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
       # Install phpunit
       - run: composer require --dev phpunit/phpunit ^9
       # By default, php is not available in /usr/bin, fix that

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
       # Install vip-go-ci from trunk branch
       - run: pushd ~/vip-go-ci-tools && wget -O vip-go-ci.tar.gz https://github.com/Automattic/vip-go-ci/archive/trunk.tar.gz && tar -zxvf vip-go-ci.tar.gz && mv vip-go-ci-trunk vip-go-ci && rm -f vip-go-ci.tar.gz && popd
       # Change path to vital tools needed
-      - run: sed 's/HOME_DIR/\/home\/circleci\//' < ~/project/unittests.ini.dist > ~/project/unittests.ini
+      - run: sed 's/HOME_DIR/\/home\/circleci/' < ~/project/unittests.ini.dist > ~/project/unittests.ini
       # Prepare phpunit configuration file
       - run: sed 's/PROJECT_DIR/\/home\/circleci\/project/g' < ~/project/phpunit.xml.dist > ~/project/phpunit.xml
       # Run unit tests

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -6,7 +6,7 @@
 	If you're not sure if something is safe to share, please just ask! 
 -->
 
-<!-- If you are filing a feature request, please have a look at the document on contributing first: https://github.com/Automattic/vip-go-ci/blob/main/CONTRIBUTING.md -->
+<!-- If you are filing a feature request, please have a look at the document on contributing first: https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md -->
 
 <!-- Please use the following template when filing a bug report: -->
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 <!-- ATTENTION: :wave: Just a quick reminder that this is a PUBLIC repository. Please do not include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask! -->
 
-<!-- Please have a look at the document on contributing before submitting a pull request: https://github.com/Automattic/vip-go-ci/blob/main/CONTRIBUTING.md -->
+<!-- Please have a look at the document on contributing before submitting a pull request: https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md -->
 
 <!--
 Pull-Requests should have a TODO included. Here is a draft:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note that the tool has two parts:
 Included is a script to install `vip-go-compatibility-scanner`. You can use it like this:
 
 ```
-wget https://raw.githubusercontent.com/Automattic/vip-go-compatibility-scanner/main/install.sh && bash ./install.sh 
+wget https://raw.githubusercontent.com/Automattic/vip-go-compatibility-scanner/trunk/install.sh && bash ./install.sh 
 ```
 
 This will result in `vip-go-compatibility-scanner`, `vip-go-ci` and other dependencies being installed in your home directory under `vip-go-ci-tools`.
@@ -202,4 +202,4 @@ These tests may create temporary files, and may depend on external scanners, ext
 
 ## Contributing
 
-If you want to contribute to this project, please see [this file](https://github.com/Automattic/vip-go-ci/blob/main/CONTRIBUTING.md) from the [vip-go-ci project](https://github.com/Automattic/vip-go-ci/) on contributing.
+If you want to contribute to this project, please see [this file](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md) from the [vip-go-ci project](https://github.com/Automattic/vip-go-ci/) on contributing.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pushd testing123 && \
 git submodule init && \
 git submodule update --recursive && \
 popd && popd && \
-./compatibility-scanner.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/"  --repo-owner="mygithubuser" --repo-name="testing123" --token="xyz" --github-labels='PHP Compatibility' --github-issue-title="PHP Upgrade: Compatibility issues found in " --github-issue-body="The following issues were found when scanning branch <code>%branch_name%</code> for compatibility problems:  %error_msg% This is an automated report." --github-issue-assign="direct" --local-git-repo="/tmp/testing123" --phpcs-path="$HOME/vip-go-ci-tools/phpcs/bin/phpcs" --phpcs-standard="PHPCompatibilityWP" --phpcs-runtime-set='testVersion 7.3-' 
+./compatibility-scanner.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/"  --repo-owner="mygithubuser" --repo-name="testing123" --token="xyz" --github-labels='PHP Compatibility' --github-issue-title="PHP Upgrade: Compatibility issues found in " --github-issue-body="The following issues were found when scanning branch <code>%branch_name%</code> for compatibility problems:  %error_msg% This is an automated report." --github-issue-assign="direct" --local-git-repo="/tmp/testing123" --phpcs-path="$HOME/vip-go-ci-tools/phpcs/bin/phpcs" --phpcs-php-path=/usr/bin/php --phpcs-standard="PHPCompatibilityWP" --phpcs-runtime-set='testVersion 7.3-' 
 ```
 
 Use the `--github-issue-group-by` option to switch between posting issues on a per `file` and `folder` basis.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note that the tool has two parts:
 
 ## System requirements
 
-- PHP 7.3 or later. PHP 7.4 is preferred. 
+- PHP 8.0 or later. PHP 8.1 is recommended. 
 - SQLite support is required if the Zendesk functionality is to be used. Same if PHPCSCacheDB functionality is to be used.
 - Linux is a preferred OS for `vip-go-compatibility-scanner`, but it should work on other platforms as well. 
 - See instructions for macOS below.

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ if [ ! -d "$HOME/vip-go-ci-tools" ] ; then
 	echo "$0: vip-go-ci-tools is not installed, installing"
 
 	cd "$TMP_DIR" && \
-	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/main/tools-init.sh && \
+	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/tools-init.sh && \
 	bash tools-init.sh
 fi
 
@@ -106,12 +106,12 @@ fi
 # Install vip-go-compatibility-scanner
 #
 cd "$TMP_DIR" && \
-wget https://github.com/Automattic/vip-go-compatibility-scanner/archive/main.zip && \
-mv main.zip vip-go-compatibility-scanner.zip && \
+wget https://github.com/Automattic/vip-go-compatibility-scanner/archive/trunk.zip && \
+mv trunk.zip vip-go-compatibility-scanner.zip && \
 unzip vip-go-compatibility-scanner.zip && \
 cd "$HOME/vip-go-ci-tools/" && \
 rm -rf "$HOME/vip-go-ci-tools/vip-go-compatibility-scanner/" && \
-mv "$TMP_DIR/vip-go-compatibility-scanner-main" "$HOME/vip-go-ci-tools/vip-go-compatibility-scanner/" && \
+mv "$TMP_DIR/vip-go-compatibility-scanner-trunk" "$HOME/vip-go-ci-tools/vip-go-compatibility-scanner/" && \
 echo "$0: vip-go-compatibility-scanner and dependencies installed" && \
 exit 0
 

--- a/main.php
+++ b/main.php
@@ -21,6 +21,7 @@ function vipgocs_options_recognized(): array {
 		 * PHPCS configuration
 		 */
 		'phpcs-path:',
+		'phpcs-php-path:',
 		'phpcs-standard:',
 		'phpcs-severity:',
 		'phpcs-runtime-set:',
@@ -78,6 +79,8 @@ function vipgocs_help( ) :void {
 		PHP_EOL .
 		"\t" . 'PHPCS configuration:' . PHP_EOL .
 		"\t" . '--phpcs-path=FILE                   Full path to PHPCS script.' . PHP_EOL .
+		"\t" . '--phpcs-php-path=FILE               Full path to PHP used to run PHPCS. If not specified the default in' . PHP_EOL .
+		"\t" . '                                    $PATH will be used instead.' . PHP_EOL .
 		"\t" . '--phpcs-standard=STRING             Specify which PHPCS standard to use.' . PHP_EOL .
 		"\t" . '--phpcs-severity=NUMBER             Specify severity for PHPCS.' . PHP_EOL .
 		"\t" . '--phpcs-runtime-set=STRING          Specify --runtime-set values passed on to PHPCS' . PHP_EOL .
@@ -249,6 +252,12 @@ function vipgocs_compatibility_scanner_init_phpcs(
 		$options,
 		'phpcs-path',
 		null
+	);
+
+	vipgoci_option_file_handle(
+		$options,
+		'phpcs-php-path',
+		'php'
 	);
 
 	vipgoci_option_array_handle(
@@ -479,7 +488,7 @@ function vipgocs_compatibility_scanner_init(
 	 * Get option-values
 	 */
 	$options = getopt(
-		null,
+		'',
 		vipgocs_options_recognized()
 	);
 

--- a/open-issues.php
+++ b/open-issues.php
@@ -216,7 +216,7 @@ function vipgocs_open_issues(
 		}
 
 		if ( false === $emulate_only ) {
-			$res = vipgoci_github_post_url(
+			$res = vipgoci_http_api_post_url(
 				$github_url,
 				$github_req_body,
 				$options['token']

--- a/tests/integration/IncludesForTests.php
+++ b/tests/integration/IncludesForTests.php
@@ -33,7 +33,7 @@ define( 'VIPGOCI_UNIT_TESTS_INI_DIR_PATH', dirname( __DIR__ ) );
 
 define( 'VIPGOCI_GITHUB_SERVER_ADDR', '127.0.0.1:15701' );
 define( 'VIPGOCI_GITHUB_BASE_URL', 'http://' . VIPGOCI_GITHUB_SERVER_ADDR );
-define( 'VIPGOCI_TEST_HTTP_SERVER_FILES_PATH', dirname( __DIR__ ) . '/tests/test-server' );
+define( 'VIPGOCI_TEST_HTTP_SERVER_FILES_PATH', dirname( __DIR__ ) . '/integration/test-server' );
 
 /*
  * Function to start test HTTP server.

--- a/tests/integration/OpenIssuesOpenIssuesTest.php
+++ b/tests/integration/OpenIssuesOpenIssuesTest.php
@@ -170,7 +170,7 @@ final class OpenIssuesOpenIssuesTest extends TestCase {
 				'errors' => 3,
 				'fixable' => 0,
 			),
-			'main-branch',
+			'trunk-branch',
 			array(
 				'my-label1',
 				'my-label2',
@@ -190,9 +190,9 @@ final class OpenIssuesOpenIssuesTest extends TestCase {
 		);
 
 		$this->assertSame(
-			'{"_POST":{"{\"title\":\"my-issue-title1file1_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'__https:\\\\\/\\\\\/github_com\\\\\\/mytestuseraccount0x900\\\\\\/testrepo18736\\\\\\/blob\\\\\\/8171\\\\\\/file1_php#L2\\\\n\\\\n\\\\n\\\\n,_main-branch\\\\n\",\"assignees\":":{"\"my-username1\",\"my-username2\"":""}},"_GET":[]}' .
-				'{"_POST":{"{\"title\":\"my-issue-title1file3_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'__https:\\\\\\/\\\\\\/github_com\\\\\\/mytestuseraccount1x900\\\\\\/testrepo19936\\\\\\/blob\\\\\\/9300\\\\\\/file3_php#L3\\\\n\\\\n\\\\n\\\\n,_main-branch\\\\n\",\"assignees\":":{"\"my-username1\",\"my-username2\"":""}},"_GET":[]}' .
-				'{"_POST":{"{\"title\":\"my-issue-title1file4_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'___In_submodule,_<a_href":"\\\\\\"https:\\\\\\/\\\\\\/github.com\\\\\\/yetanothertestaccount1x900\\\\\\/testrepo39999\\\\\\/blob\\\\\\/18900\\\\\\/file4.php#L30\\\\\\">here<\\\\\\/a>.\\\\n\\\\n\\\\n\\\\n, main-branch\\\\n\",\"assignees\":[\"my-username1\",\"my-username2\"]}"},"_GET":[]}',
+			'{"_POST":{"{\"title\":\"my-issue-title1file1_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'__https:\\\\\/\\\\\/github_com\\\\\\/mytestuseraccount0x900\\\\\\/testrepo18736\\\\\\/blob\\\\\\/8171\\\\\\/file1_php#L2\\\\n\\\\n\\\\n\\\\n,_trunk-branch\\\\n\",\"assignees\":":{"\"my-username1\",\"my-username2\"":""}},"_GET":[]}' .
+				'{"_POST":{"{\"title\":\"my-issue-title1file3_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'__https:\\\\\\/\\\\\\/github_com\\\\\\/mytestuseraccount1x900\\\\\\/testrepo19936\\\\\\/blob\\\\\\/9300\\\\\\/file3_php#L3\\\\n\\\\n\\\\n\\\\n,_trunk-branch\\\\n\",\"assignees\":":{"\"my-username1\",\"my-username2\"":""}},"_GET":[]}' .
+				'{"_POST":{"{\"title\":\"my-issue-title1file4_php\",\"body\":\"my-issue-body1,_\\\\n*_<b>Error<\\\\\\/b>:_All_output_should_be_run_through_an_escaping_function_(see_the_Security_sections_in_the_WordPress_Developer_Handbooks),_found_\'time\'___In_submodule,_<a_href":"\\\\\\"https:\\\\\\/\\\\\\/github.com\\\\\\/yetanothertestaccount1x900\\\\\\/testrepo39999\\\\\\/blob\\\\\\/18900\\\\\\/file4.php#L30\\\\\\">here<\\\\\\/a>.\\\\n\\\\n\\\\n\\\\n, trunk-branch\\\\n\",\"assignees\":[\"my-username1\",\"my-username2\"]}"},"_GET":[]}',
 
 			file_get_contents(
 				$this->output_file

--- a/tests/integration/ScanFilesScanFilesTest.php
+++ b/tests/integration/ScanFilesScanFilesTest.php
@@ -14,9 +14,10 @@ final class ScanFilesScanFilesTest extends TestCase {
 	);
 
 	var $options_phpcs_scan = array(
-		'phpcs-path'		=> null,
-		'phpcs-standard'	=> null,
-		'phpcs-severity'	=> null,
+		'phpcs-path'     => null,
+		'phpcs-php-path' => null,
+		'phpcs-standard' => null,
+		'phpcs-severity' => null,
 	);
 
 	/*

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -3,6 +3,7 @@ git-path=/usr/bin/git
 
 [phpcs-scan]
 phpcs-path=HOME_DIR/vip-go-ci-tools/phpcs/bin/phpcs
+phpcs-php-path=/usr/bin/php
 phpcs-standard=WordPress-VIP-Go
 phpcs-severity=1
 

--- a/utils.php
+++ b/utils.php
@@ -1,14 +1,14 @@
 <?php
 
 /*
- * Check if we are running on PHP 7.3 or later.
+ * Check if we are running on PHP 8.0 or later.
  */
 function vipgocs_env_check() :void {
 	if ( version_compare(
 		phpversion(),
-		'7.3.0'
+		'8.0.0'
 	) < 0 ) {
-		echo 'Error: PHP 7.3 is required as a minimum.' . PHP_EOL;
+		echo 'Error: PHP 8.0 is required as a minimum.' . PHP_EOL;
 		exit( 251 ); /* System problem */
 	}
 }


### PR DESCRIPTION
Updates `README.md`, CircleCI files, template files in `.github` and a test to reflect that the `main` branch is now named `trunk`.

TODO:
- [x] Update `.github` template files.
- [x] Update CircleCI files.
- [x] Update `tests/integration/OpenIssuesOpenIssuesTest.php`.
- [x] Update README.
- [x] Remove PHP 7.3/7.4 support as `vip-go-ci` requires 8.0/8.1.
- [x] Check automated tests
