### PR TITLE
Introduce updates due to vip-go-ci changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pushd testing123 && \
 git submodule init && \
 git submodule update --recursive && \
 popd && popd && \
-./compatibility-scanner.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/"  --repo-owner="mygithubuser" --repo-name="testing123" --token="xyz" --github-labels='PHP Compatibility' --github-issue-title="PHP Upgrade: Compatibility issues found in " --github-issue-body="The following issues were found when scanning branch <code>%branch_name%</code> for compatibility problems:  %error_msg% This is an automated report." --github-issue-assign="direct" --local-git-repo="/tmp/testing123" --phpcs-path="$HOME/vip-go-ci-tools/phpcs/bin/phpcs" --phpcs-standard="PHPCompatibilityWP" --phpcs-runtime-set='testVersion 7.3-' 
+./compatibility-scanner.php --vipgoci-path="$HOME/vip-go-ci-tools/vip-go-ci/"  --repo-owner="mygithubuser" --repo-name="testing123" --token="xyz" --github-labels='PHP Compatibility' --github-issue-title="PHP Upgrade: Compatibility issues found in " --github-issue-body="The following issues were found when scanning branch <code>%branch_name%</code> for compatibility problems:  %error_msg% This is an automated report." --github-issue-assign="direct" --local-git-repo="/tmp/testing123" --phpcs-path="$HOME/vip-go-ci-tools/phpcs/bin/phpcs" --phpcs-php-path=/usr/bin/php --phpcs-standard="PHPCompatibilityWP" --phpcs-runtime-set='testVersion 7.3-' 
 ```
 
 Use the `--github-issue-group-by` option to switch between posting issues on a per `file` and `folder` basis.

--- a/main.php
+++ b/main.php
@@ -21,6 +21,7 @@ function vipgocs_options_recognized(): array {
 		 * PHPCS configuration
 		 */
 		'phpcs-path:',
+		'phpcs-php-path:',
 		'phpcs-standard:',
 		'phpcs-severity:',
 		'phpcs-runtime-set:',
@@ -78,6 +79,8 @@ function vipgocs_help( ) :void {
 		PHP_EOL .
 		"\t" . 'PHPCS configuration:' . PHP_EOL .
 		"\t" . '--phpcs-path=FILE                   Full path to PHPCS script.' . PHP_EOL .
+		"\t" . '--phpcs-php-path=FILE               Full path to PHP used to run PHPCS. If not specified the default in' . PHP_EOL .
+		"\t" . '                                    $PATH will be used instead.' . PHP_EOL .
 		"\t" . '--phpcs-standard=STRING             Specify which PHPCS standard to use.' . PHP_EOL .
 		"\t" . '--phpcs-severity=NUMBER             Specify severity for PHPCS.' . PHP_EOL .
 		"\t" . '--phpcs-runtime-set=STRING          Specify --runtime-set values passed on to PHPCS' . PHP_EOL .
@@ -249,6 +252,12 @@ function vipgocs_compatibility_scanner_init_phpcs(
 		$options,
 		'phpcs-path',
 		null
+	);
+
+	vipgoci_option_file_handle(
+		$options,
+		'phpcs-php-path',
+		'php'
 	);
 
 	vipgoci_option_array_handle(
@@ -479,7 +488,7 @@ function vipgocs_compatibility_scanner_init(
 	 * Get option-values
 	 */
 	$options = getopt(
-		null,
+		'',
 		vipgocs_options_recognized()
 	);
 

--- a/open-issues.php
+++ b/open-issues.php
@@ -216,7 +216,7 @@ function vipgocs_open_issues(
 		}
 
 		if ( false === $emulate_only ) {
-			$res = vipgoci_github_post_url(
+			$res = vipgoci_http_api_post_url(
 				$github_url,
 				$github_req_body,
 				$options['token']

--- a/tests/integration/ScanFilesScanFilesTest.php
+++ b/tests/integration/ScanFilesScanFilesTest.php
@@ -14,9 +14,10 @@ final class ScanFilesScanFilesTest extends TestCase {
 	);
 
 	var $options_phpcs_scan = array(
-		'phpcs-path'		=> null,
-		'phpcs-standard'	=> null,
-		'phpcs-severity'	=> null,
+		'phpcs-path'     => null,
+		'phpcs-php-path' => null,
+		'phpcs-standard' => null,
+		'phpcs-severity' => null,
 	);
 
 	/*

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -3,6 +3,7 @@ git-path=/usr/bin/git
 
 [phpcs-scan]
 phpcs-path=HOME_DIR/vip-go-ci-tools/phpcs/bin/phpcs
+phpcs-php-path=/usr/bin/php
 phpcs-standard=WordPress-VIP-Go
 phpcs-severity=1
 


### PR DESCRIPTION
`vip-go-ci` has changed recently, updating function names and adding new options. This pull request updates `vip-go-compatibility-scanner` to reflect these changes.

TODO:
- [x] Specify a parameter to make path to PHP to execute PHPCS configurable (`--phpcs-php-path`).
  - [x] Update `README.md`, adding this option to example.
- [x] Change function call `vipgoci_github_post_url()` to `vipgoci_http_api_post_url()`.
- [x] Fix `getopt()` call, first parameter should be string.
- [x] Update unit-tests so that `php-phpcs-path` option is now specified.
- [x] Check automated unit-tests.

