### PR TITLE
Fix md5sha1sum install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,14 +2,15 @@
 
 #
 # Support function to check for utilities
+# exit code 127: command does not exist
+# exit code 126: command exists but it is not executable
 #
 function check_utility() {
 	TMP_CMD="$1"
 	$TMP_CMD --help >/dev/null 2>/dev/null
-
-	if [ "$?" != "0" ] ; then
-		echo "$0: Missing utility $TMP_CMD, needs to be installed"
-		exit 1
+	EXIT_CODE="$?";
+	if [ "$EXIT_CODE" == "127" ] || [ "$EXIT_CODE" == "126" ] ; then
+		echo "Missing utility $TMP_CMD, needs to be installed. - Exit code: $EXIT_CODE"
 	fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,11 @@ if [[ "$OSTYPE" =~ "darwin" ]] ; then
 	sha1sum --help >/dev/null 2>/dev/null
 
 	if [ "$?" != "0" ] ; then
-		TMP_INSTALL="$TMP_INSTALL md5sha1sum"
+		if [ "$TMP_INSTALL" == "" ]; then
+			TMP_INSTALL="md5sha1sum"
+		else
+			TMP_INSTALL="$TMP_INSTALL md5sha1sum"
+		fi
 	fi
 
 	if [ "$TMP_INSTALL" != "" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -36,10 +36,17 @@ fi
 if [[ "$OSTYPE" =~ "darwin" ]] ; then
 	TMP_INSTALL=""
 
+  ##
+  ## @todo: remove code duplication
+  ##
 	wget --help >/dev/null 2>/dev/null
 
 	if [ "$?" != "0" ] ; then
-		TMP_INSTALL="$TMP_INSTALL wget"
+		if [ "$TMP_INSTALL" == "" ]; then
+			TMP_INSTALL="wget"
+		else
+			TMP_INSTALL="$TMP_INSTALL wget"
+		fi
 	fi
 
 	alias sha1sum='shasum -a 1'


### PR DESCRIPTION
1. The ``install.sh`` script, executes ``brew install`` for  the project dependencies. 
And it incorrectly adds a blank string before the name of the dependency.

This PR addresses the issue by adding a verification that will only add the blank space when the TMP_INSTALL var contains a value.

2. There's a false negative during the ``check_utility`` function execution as well. 
Functions that exist were pointed out as missing, eg.  shasum.

This PR addresses it by checking the utility's existence by verifying the exit codes 127 and 126, which are the ones returned by the OS for non-existent/non-executable commands. 


TODO:
- [ X ] Manual testing
