### PR TITLE
Define longer wait time between HTTP API requests

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -3,3 +3,5 @@
 define( 'VIPGOCS_PHPCS_CACHEDB_TABLE_NAME', 'vipgocs_phpcs_cachedb' );
 define( 'VIPGOCS_PHPCS_CACHEDB_INDEX_NAME', 'vipgocs_phpcs_cachedb_index' );
 define( 'VIPGOCS_PHPCS_SOURCE_INTERNAL',    'Vipgocs.Internal' );
+
+define( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS', 5 );


### PR DESCRIPTION
Ensure longer wait time between HTTP API requests to GitHub API by defining longer wait time via `VIPGOCI_HTTP_API_WAIT_TIME_SECONDS` define.

Relates to https://github.com/Automattic/vip-go-ci/pull/316

- [x] Define `VIPGOCI_HTTP_API_WAIT_TIME_SECONDS` as `5`.
- [x] Check automated unit-tests

