### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP environment
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: ${{ matrix.php }}
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP environment
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: ${{ matrix.php }}


### PR DESCRIPTION
This pull request will update GitHub Actions dependencies to the latest. This will resolve a few annotation warnings, see for example [here](https://github.com/Automattic/vip-go-compatibility-scanner/actions/runs/3321684665).

TODO:
- [x] Update `shivammathur/setup-php` to version `2.21.2`
- [x] Check automated unit-tests
