### PR TITLE
Set --skip-large-files option

### DIFF
--- a/main.php
+++ b/main.php
@@ -526,6 +526,11 @@ function vipgocs_compatibility_scanner_init(
 	);
 
 	/*
+	 * Do not skip large files.
+	 */
+	$options['skip-large-files'] = false;
+
+	/*
 	 * Intialize Zendesk options.
 	 */
 	vipgocs_compatibility_scanner_init_zendesk(


### PR DESCRIPTION

This pull request will set the `skip-large-files` option to `false`, as it is not meaningful for the scanner, and is needed as well to silence warnings.

TODO:
- [x] Set the `skip-large-files option` to `false`. 
- [x] Check automated unit-tests
- [x] Manual testing

